### PR TITLE
feat: implementando redirecionamento após pedido concluido

### DIFF
--- a/app/(website)/order/actions.js
+++ b/app/(website)/order/actions.js
@@ -130,7 +130,7 @@ export async function createOrder({ billing_address, shipping_same_as_billing, s
     })
 
     console.log("🚀 ~ file: actions.js:129 ~ createOrder ~ items2:", items2)
-
+    
     return { order: order }
 
 }
@@ -143,4 +143,9 @@ export async function GetAddressesFromUserId(user) {
             }
         }
     })
+}
+
+export async function redirectToStatusPage(id){
+    redirect(`/statusPedido/${id}`)
+
 }

--- a/app/(website)/order/page.js
+++ b/app/(website)/order/page.js
@@ -5,7 +5,7 @@ import ProductList from '@/components/order/productList';
 import RadioButton from '@/components/order/radioButton';
 import { CreditCardIcon } from "lucide-react";
 import { useCart } from '@/components/CartContext';
-import { GetAddressesFromUserId, createOrder } from './actions';
+import { GetAddressesFromUserId, createOrder, redirectToStatusPage } from './actions';
 import { Switch } from '@/components/ui/switch';
 import { toast } from 'react-toastify';
 import { redirect } from 'next/dist/server/api-utils';
@@ -58,8 +58,7 @@ const CheckoutPage = () => {
         if (res) {
             if (res.order) {
                 toast.success('Pedido criado com sucesso!')
-                // TODO redirecionar para a página
-                // redirect(`/statusPedido/${res.order.id}`)
+                redirectToStatusPage(res.order.id)
             } else if (res.error) {
                 toast.error('Erro ao criar o pedido. ' + res.error)
             } else {


### PR DESCRIPTION
Implementei o redirect para o status pedido após o pedido ser cadastrado com sucesso. **Porém tenho duas observações:**

**O 1º ponto** é sobre a página status pedido, que tem layout definido de acordo com o status. Atualmente são 4(_completado, pendente, processando e cancelado)_

Seria bom ao criar o pedido, já definir um desses status para o mesmo, para que a visualização fique fidedigna.

**O 2º ponto** que observei é que ao alterar a quantidade de um item no carrinho para 0, ele não é removido. Como consequência, quando o pedido é efetuado ele é salvo junto com o pedido com 0 quantidade.


