### PR TITLE
[issue-86] fix: :bug: removed unused header's links

### DIFF
--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -25,46 +25,32 @@ export default function Navbar() {
 	}, [])
 	return (
 		<header className="flex justify-between items-center gap-10 max-w-7xl w-full text-zinc-900 border-b border-b-zinc-100 py-5 px-8">
-			<Image src="/static/images/logo.png" alt="me" width="64" height="64" />
-			<h1 className="font-primary font-black text-3xl">
-				{name ? name : 'SHOPIC'}
-			</h1>
-			<nav className="flex flex-row gap-6">
-				<Link
-					href="/"
-					className="w-max hover:opacity-60 transition-opacity"
-				>
-					Shop
-				</Link>
-				<Link
-					href="/"
-					className="w-max hover:opacity-60 transition-opacity"
-				>
-					Em Promoção
-				</Link>
-				<Link
-					href="/"
-					className="w-max hover:opacity-60 transition-opacity"
-				>
-					Novos produtos
-				</Link>
-				<Link
-					href="/"
-					className="w-max hover:opacity-60 transition-opacity"
-				>
-					Marcas
-				</Link>
-			</nav>
-			<SearchProduct placeholder="Busque por produto" />
-			<div className="flex items-center gap-4">
-				<div className="relative">
-					<Link href="/cart">
-						<ShoppingCart className="text-xl cursor-pointer" />
-						<NavbarCart></NavbarCart>
+			<div className="flex items-center gap-5">
+				<Image src="/static/images/logo.png" alt="me" width="64" height="64" />
+				<h1 className="font-primary font-black text-3xl">
+					{name ? name : 'SHOPIC'}
+				</h1>
+				<nav className="flex flex-row pl-6">
+					<Link
+						href="/"
+						className="w-max hover:opacity-60 transition-opacity"
+					>
+						Shop
 					</Link>
-				</div>
-				<div>
-					<UserCircle2 className="text-xl cursor-pointer" />
+				</nav>
+			</div>
+			<div className="flex items-center w-max-1/3 gap-10">
+				<SearchProduct placeholder="Busque por produto" />
+				<div className="flex items-center gap-4">
+					<div className="relative">
+						<Link href="/cart">
+							<ShoppingCart className="text-xl cursor-pointer" />
+							<NavbarCart></NavbarCart>
+						</Link>
+					</div>
+					<div>
+						<UserCircle2 className="text-xl cursor-pointer" />
+					</div>
 				</div>
 			</div>
 		</header>


### PR DESCRIPTION
Objetivo da issue é limpar a navbar da nossa Home, removendo todos os links que não estão sendo usados. Com isso, apenas o link `Shop` deveria permanecer.

### Evidência:
![Screenshot from 2023-11-05 21-23-09](https://github.com/Murphyly/mate85_ecommerce/assets/83042571/410e1faa-bf95-4020-abf8-5fd2174b42aa)
