### PR TITLE
feat: :lipstick: barra de pesquisa do header expandida para ocupar todo o espaco disponível

### DIFF
--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -39,7 +39,7 @@ export default function Navbar() {
 					</Link>
 				</nav>
 			</div>
-			<div className="flex items-center w-max-1/3 gap-10">
+			<div className="flex items-center flex-1 gap-10">
 				<SearchProduct placeholder="Busque por produto" />
 				<div className="flex items-center gap-4">
 					<div className="relative">


### PR DESCRIPTION
A pedido de @Shirkit, estilizando a searchBAr para que ela ocupe todo o espaco restante disponível.

### Evidência:
![Screenshot from 2023-11-09 12-24-44](https://github.com/Murphyly/mate85_ecommerce/assets/83042571/9923d18a-4d16-4d57-a3e2-252bf329f6ac)