### PR TITLE
raw: :pencil: added order status translator

### DIFF
--- a/app/admin/dashboard/components/ordersTable.js
+++ b/app/admin/dashboard/components/ordersTable.js
@@ -6,6 +6,7 @@ import { Fragment, useEffect, useState } from 'react';
 import { Dialog, Transition } from "@headlessui/react";
 import ProductList from '@/components/order/productList';
 import { updateStatus } from '../actions';
+import { statusTranslator } from '@/utils/orderStatusTranslator';
 
 const deltaTypes = {
     waiting: { icon: ClockIcon, color: 'gray' },
@@ -112,7 +113,7 @@ function OrdersTable({ orders, total }) {
                                     <TableCell className="text-right">{numberformatter(order.total, 2)}</TableCell>
                                     <TableCell className="text-right">
                                         <Badge icon={deltaTypes[order.status].icon} color={deltaTypes[order.status].color}>
-                                            {order.status}
+                                            {statusTranslator(order.status)}
                                         </Badge>
                                     </TableCell>
                                     <TableCell>
@@ -163,7 +164,7 @@ function OrdersTable({ orders, total }) {
                                             <Select onValueChange={setSelectedStatus} placeholder='Selecione o status...'>
                                                 {Object.keys(deltaTypes).map((key, index) => (
                                                     <SelectItem key={index} value={key}>
-                                                        {key}
+                                                        {statusTranslator(key)}
                                                     </SelectItem>
                                                 ))}
                                             </Select>

--- a/utils/orderStatusTranslator.js
+++ b/utils/orderStatusTranslator.js
@@ -1,0 +1,15 @@
+let dictionary = {
+    "completed": "concluído",
+    "shipped": "enviado",
+    "payment-pending": "pagamento pendente",
+    "processing": "em processamento",
+    "waiting": "aguardando",
+    "delivered": "entregue"
+} 
+
+export function statusTranslator(status) {
+    if (!Object.keys(dictionary).includes(status)) {
+        return "status desconhecido"
+    }
+    return dictionary[status]
+} 


### PR DESCRIPTION
Closes #100 
Adicionei uma nova função auxiliar para traduzir os status dos pedidos de inglês para português.

*Obs: Se souberem de alguma outra tela onde os status dos pedidos estão sendo exibidos por favor avisem pra que eu possa fazer a alteração*

### Evidência:
![Screenshot from 2023-11-19 22-34-30](https://github.com/Murphyly/mate85_ecommerce/assets/83042571/f4997f43-78e1-47af-85e2-8fcbf98466e0)

