### PR TITLE
Status canceled

### DIFF
--- a/app/admin/dashboard/components/ordersTable.js
+++ b/app/admin/dashboard/components/ordersTable.js
@@ -1,7 +1,7 @@
 'use client'
 
 import { Table, TableHead, TableRow, TableHeaderCell, TableBody, TableCell, Card, Flex, Title, Icon, Badge, Text, Metric, Button, DateRangePicker, SearchSelect, SearchSelectItem, Divider, Select, SelectItem, } from '@tremor/react';
-import { AlertCircleIcon, CheckIcon, ClockIcon, LoaderIcon, MoreHorizontalIcon, PackageCheckIcon, SearchIcon, TruckIcon } from 'lucide-react';
+import { AlertCircleIcon, CheckIcon, ClockIcon, LoaderIcon, MoreHorizontalIcon, PackageCheckIcon, SearchIcon, TruckIcon, XCircle  } from 'lucide-react';
 import { Fragment, useEffect, useState } from 'react';
 import { Dialog, Transition } from "@headlessui/react";
 import ProductList from '@/components/order/productList';
@@ -10,11 +10,12 @@ import { statusTranslator } from '@/utils/orderStatusTranslator';
 
 const deltaTypes = {
     waiting: { icon: ClockIcon, color: 'gray' },
-    "payment-pending": { icon: ClockIcon, color: 'red' },
+    "payment-pending": { icon: ClockIcon, color: 'yellow' },
     completed: { icon: CheckIcon, color: 'emerald' },
     shipped: { icon: TruckIcon, color: 'lime' },
     delivered: { icon: PackageCheckIcon, color: 'green' },
     processing: { icon: LoaderIcon, color: 'blue' },
+    "canceled": {icon: XCircle , color:'red' },
 }
 
 const numberformatter = (number, decimals = 0) =>

--- a/app/admin/order/page.js
+++ b/app/admin/order/page.js
@@ -26,6 +26,8 @@ export default async function ManageOrders() {
             case "processing": element.status = "Processando"; break
             case "waiting": element.status = "Aguardando"; break
             case "delivered": element.status = "Entregue"; break
+            case "canceled": element.status = "Cancelado"; break
+            //status
         }
     }
 

--- a/components/statusPedido/CardConfirmacao.jsx
+++ b/components/statusPedido/CardConfirmacao.jsx
@@ -88,7 +88,7 @@ export default async function CardConfirmacao(props) {
       <div className=' p-4 h-auto md:h-2/6 border border-black w-auto md:w-2/4 rounded-sm '>
         <h4 className='font-bold'>Informações Do Pedido</h4>
         <br></br>
-        <p> Numero do pedido: {pedido.order_number}</p>
+        <p> Numero do pedido: {pedido.id}</p>
         <br></br>
         <div className='flex justify-center bg-black text-white'>Items</div>
 

--- a/utils/orderStatusTranslator.js
+++ b/utils/orderStatusTranslator.js
@@ -4,7 +4,8 @@ let dictionary = {
     "payment-pending": "pagamento pendente",
     "processing": "em processamento",
     "waiting": "aguardando",
-    "delivered": "entregue"
+    "delivered": "entregue",
+    "canceled": "cancelado",
 } 
 
 export function statusTranslator(status) {


### PR DESCRIPTION
Adicionando status cancelado ao pedido e alterando o numero do pedido da página status pedido para ser igual ao id do pedido.
Antes utilizava o order_number mas foi descontinuado